### PR TITLE
ci: publish containers to GHCR

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,3 +12,4 @@ jobs:
     permissions:
       contents: read
       packages: write
+    secrets: inherit

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -2,22 +2,13 @@ name: CI
 
 on:
   push:
-    branches: ["**"]
+    branches: [ main ]
   pull_request:
-    branches: ["**"]
+    branches: [ main ]
 
 jobs:
-  ci:
-    runs-on: ubuntu-latest
+  call-common-ci:
+    uses: its-the-vibe/.github/.github/workflows/common-ci.yaml@main
     permissions:
       contents: read
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Set up Go
-        uses: actions/setup-go@v5
-        with:
-          go-version-file: go.mod
-
-      - name: Run CI (lint + test)
-        run: make ci
+      packages: write

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,7 @@
-FROM golang:1.26.6-alpine AS builder
+FROM --platform=$BUILDPLATFORM golang:1.26.6-alpine AS builder
+
+ARG TARGETOS
+ARG TARGETARCH
 
 WORKDIR /app
 
@@ -6,13 +9,12 @@ COPY go.mod go.sum ./
 RUN go mod download
 
 COPY . .
-RUN CGO_ENABLED=0 GOOS=linux go build -trimpath -ldflags="-s -w" -o redsub .
+RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build -trimpath -ldflags="-s -w" -o redsub .
 
-FROM scratch
-
-# CA certificates are required for TLS connections to GCP Pub/Sub.
-COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
+FROM gcr.io/distroless/static-debian13:nonroot
 
 COPY --from=builder /app/redsub /redsub
+
+USER nonroot:nonroot
 
 ENTRYPOINT ["/redsub", "--config", "/config.yaml"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,8 @@
 services:
   redsub:
     build: .
+    image: ghcr.io/its-the-vibe/redsub:latest
+    pull_policy: always
     read_only: true
     restart: on-failure:10
     extra_hosts:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,6 +4,7 @@ services:
     image: ghcr.io/its-the-vibe/redsub:latest
     pull_policy: always
     read_only: true
+    user: "${UID:-65532}:${GID:-65532}"
     restart: on-failure:10
     extra_hosts:
       - "host.docker.internal:host-gateway"


### PR DESCRIPTION
## Summary
- Build cross-platform static binary using `--platform=$BUILDPLATFORM` with `TARGETOS`/`TARGETARCH` args
- Switch runtime from `scratch` to `gcr.io/distroless/static-debian13:nonroot` (removes CA cert copy)
- Add `USER nonroot:nonroot` instruction
- Update Compose to use GHCR image with `pull_policy: always`
- Delegate CI/CD to the shared organisation workflow